### PR TITLE
added V4R as dependency where needed and changed maintainers to STRANDS people

### DIFF
--- a/camera_tracker/package.xml
+++ b/camera_tracker/package.xml
@@ -7,13 +7,15 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="aitor@todo.todo">aitor</maintainer>
+  <maintainer email="faeulhammer@acin.tuwien.ac.at">Thomas Faeulhammer</maintainer>
+  <maintainer email="alexandrov@acin.tuwien.ac.at">Sergey Alexandrov</maintainer>
+  <maintainer email="zillich@acin.tuwien.ac.at">Michael Zillich</maintainer>
 
 
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>MIT</license>
 
 
   <!-- Url tags are optional, but mutiple are allowed, one per tag -->
@@ -49,6 +51,7 @@
   <build_depend>visualization_msgs</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>image_transport</build_depend>
+  <build_depend>v4r</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
@@ -59,6 +62,7 @@
   <run_depend>visualization_msgs</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>image_transport</run_depend>
+  <run_depend>v4r</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/camera_tracker_srv_definitions/package.xml
+++ b/camera_tracker_srv_definitions/package.xml
@@ -7,13 +7,11 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="faeulhammer@acin.tuwien.ac.at">Thomas Fäulhammer</maintainer>
+  <maintainer email="faeulhammer@acin.tuwien.ac.at">Thomas Faeulhammer</maintainer>
+  <maintainer email="alexandrov@acin.tuwien.ac.at">Sergey Alexandrov</maintainer>
+  <maintainer email="zillich@acin.tuwien.ac.at">Michael Zillich</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>MIT</license>
 
 
   <!-- Url tags are optional, but mutiple are allowed, one per tag -->

--- a/classifier_srv_definitions/package.xml
+++ b/classifier_srv_definitions/package.xml
@@ -7,13 +7,11 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="faeulhammer@acin.tuwien.ac.at">Thomas Fäulhammer</maintainer>
+  <maintainer email="faeulhammer@acin.tuwien.ac.at">Thomas Faeulhammer</maintainer>
+  <maintainer email="alexandrov@acin.tuwien.ac.at">Sergey Alexandrov</maintainer>
+  <maintainer email="zillich@acin.tuwien.ac.at">Michael Zillich</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>MIT</license>
 
 
   <!-- Url tags are optional, but mutiple are allowed, one per tag -->

--- a/multiview_object_recognizer/package.xml
+++ b/multiview_object_recognizer/package.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0"?>
 <package>
   <name>multiview_object_recognizer</name>
-  <version>1.0.0</version>
+  <version>0.0.0</version>
   <description>The multiview_object_recognizer package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="faeulhammer@acin.tuwien.ac.at">Thomas Faeulhammer</maintainer>
+  <maintainer email="alexandrov@acin.tuwien.ac.at">Sergey Alexandrov</maintainer>
+  <maintainer email="zillich@acin.tuwien.ac.at">Michael Zillich</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>MIT</license>
 
 
@@ -53,6 +51,10 @@
   <run_depend>cv_bridge</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>image_transport</run_depend>
+
+  <build_depend>v4r</build_depend>
+  <run_depend>v4r</run_depend>
+
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/object_classifier/package.xml
+++ b/object_classifier/package.xml
@@ -48,14 +48,15 @@
 	<build_depend>object_perception_msgs</build_depend>
         <build_depend>segmentation_srv_definitions</build_depend>
         <build_depend>classifier_srv_definitions</build_depend>
-        <build_depend>strands_v4r</build_depend>
+        <build_depend>v4r</build_depend>
+        <run_depend>v4r</run_depend>
 	<run_depend>roscpp</run_depend>
 	<run_depend>sensor_msgs</run_depend>
         <run_depend>std_msgs</run_depend>
         <run_depend>object_perception_msgs</run_depend>
         <run_depend>segmentation_srv_definitions</run_depend>
         <run_depend>classifier_srv_definitions</run_depend>
-        <run_depend>strands_v4r</run_depend>
+        <run_depend>v4r</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/object_perception_msgs/package.xml
+++ b/object_perception_msgs/package.xml
@@ -7,14 +7,11 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="faeulhammer@acin.tuwien.ac.at">Thomas Fäulhammer</maintainer>
-  <maintainer email="aldoma@acin.tuwien.ac.at">Aitor Aldoma</maintainer>
+  <maintainer email="faeulhammer@acin.tuwien.ac.at">Thomas Faeulhammer</maintainer>
+  <maintainer email="alexandrov@acin.tuwien.ac.at">Sergey Alexandrov</maintainer>
+  <maintainer email="zillich@acin.tuwien.ac.at">Michael Zillich</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>MIT</license>
 
 
   <!-- Url tags are optional, but mutiple are allowed, one per tag -->

--- a/recognition_srv_definitions/package.xml
+++ b/recognition_srv_definitions/package.xml
@@ -7,13 +7,11 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="faeulhammer@acin.tuwien.ac.at">Thomas Fäulhammer</maintainer>
+  <maintainer email="faeulhammer@acin.tuwien.ac.at">Thomas Faeulhammer</maintainer>
+  <maintainer email="alexandrov@acin.tuwien.ac.at">Sergey Alexandrov</maintainer>
+  <maintainer email="zillich@acin.tuwien.ac.at">Michael Zillich</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>MIT</license>
 
 
   <!-- Url tags are optional, but mutiple are allowed, one per tag -->

--- a/segmentation/package.xml
+++ b/segmentation/package.xml
@@ -25,6 +25,10 @@
   <run_depend>rospy</run_depend>
   <run_depend>segmentation_srv_definitions</run_depend>
 
+  <build_depend>v4r</build_depend>
+  <run_depend>v4r</run_depend>
+
+
   <export>
 
   </export>

--- a/segmentation_srv_definitions/package.xml
+++ b/segmentation_srv_definitions/package.xml
@@ -7,13 +7,11 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="faeulhammer@acin.tuwien.ac.at">Thomas Fäulhammer</maintainer>
+  <maintainer email="faeulhammer@acin.tuwien.ac.at">Thomas Faeulhammer</maintainer>
+  <maintainer email="alexandrov@acin.tuwien.ac.at">Sergey Alexandrov</maintainer>
+  <maintainer email="zillich@acin.tuwien.ac.at">Michael Zillich</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>MIT</license>
 
 
   <!-- Url tags are optional, but mutiple are allowed, one per tag -->

--- a/singleview_object_recognizer/package.xml
+++ b/singleview_object_recognizer/package.xml
@@ -7,8 +7,9 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="faeulhammer@acin.tuwien.ac.at">aitor</maintainer>
-
+  <maintainer email="faeulhammer@acin.tuwien.ac.at">Thomas Faeulhammer</maintainer>
+  <maintainer email="alexandrov@acin.tuwien.ac.at">Sergey Alexandrov</maintainer>
+  <maintainer email="zillich@acin.tuwien.ac.at">Michael Zillich</maintainer>
 
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
@@ -47,6 +48,9 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>image_transport</build_depend>
+
+  <build_depend>v4r</build_depend>
+  <run_depend>v4r</run_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>


### PR DESCRIPTION
- All licenses of this now MIT
- all maintainers now STRANDS people
- all packages that need it depend in V4R

It still fails locally:

```
[100%] Building CXX object v4r_ros_wrappers/camera_tracker/CMakeFiles/camera_tracker_service.dir/src/camera_tracker.cpp.o
In file included from /opt/ros/indigo/include/v4r/features/FeatureDetectorHeaders.h:38:0,
                 from /opt/ros/indigo/include/v4r/reconstruction/KeypointPoseDetectorRT.h:44,
                 from /opt/ros/indigo/include/v4r/reconstruction/KeyframeManagementRGBD2.h:45,
                 from /opt/ros/indigo/include/v4r/reconstruction/KeypointSlamRGBD2.h:46,
                 from /home/marc/workspace/v4r_ws/src/v4r_ros_wrappers/camera_tracker/src/camera_tracker.cpp:48:
/opt/ros/indigo/include/v4r/features/FeatureDetector_D_FREAK.h:58:11: error: ‘FREAK’ is not a member of ‘cv’
   cv::Ptr<cv::FREAK> extractor;
           ^
/opt/ros/indigo/include/v4r/features/FeatureDetector_D_FREAK.h:58:11: error: ‘FREAK’ is not a member of ‘cv’
/opt/ros/indigo/include/v4r/features/FeatureDetector_D_FREAK.h:58:20: error: template argument 1 is invalid
   cv::Ptr<cv::FREAK> extractor;
                    ^
```

But as discussed by email, this probably needs fixing in V4R.
