### PR TITLE
default was *very* specific and shouldn't be

### DIFF
--- a/singleview_object_recognizer/launch/recognition_service.launch
+++ b/singleview_object_recognizer/launch/recognition_service.launch
@@ -1,5 +1,5 @@
 <launch>
-	<arg name="data_dir" default="/home/mz/work/STRANDS/code/catkin_ws/src/v4r_ros_wrappers/singleview_object_recognizer/data" />
+	<arg name="data_dir" /> <!-- e.g.  data_dir:="/home/mz/work/STRANDS/code/catkin_ws/src/v4r_ros_wrappers/singleview_object_recognizer/data" -->
 	<arg name="do_sift" default="true" />
 	<arg name="do_shot" default="false" />
 	<arg name="do_ourcvfh" default="false" />


### PR DESCRIPTION
This confused a lot of people as the component simply throws a `boost::filesystem` error when the directory doesn't exist. Here, we should not define a default, but force people to actually define the argument, as it is a required one.

as discussed with @cdondrup 
