### PR TITLE
made the version the same on object_tracker...

### DIFF
--- a/object_tracker/include/object_tracker.h
+++ b/object_tracker/include/object_tracker.h
@@ -51,7 +51,7 @@
 #include <pcl/visualization/pcl_visualizer.h>
 
 #include <pcl/io/grabber.h>
-#include <pcl/io/openni2_grabber.h>
+//#include <pcl/io/openni2_grabber.h>
 
 
 namespace v4r

--- a/object_tracker/package.xml
+++ b/object_tracker/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>object_tracker</name>
-  <version>0.0.0</version>
+  <version>0.0.10</version>
   <description>Tracks on demand the full pose of a (previously) modelled object</description>
 
 

--- a/segment_and_classify/src/test.cpp
+++ b/segment_and_classify/src/test.cpp
@@ -78,8 +78,7 @@ public:
 
     bool callUsingFiles()
     {
-        std::vector<std::string> test_cloud;
-        v4r::io::getFilesInDirectory(directory_, test_cloud, "", ".*.pcd", false);
+        std::vector<std::string> test_cloud = v4r::io::getFilesInDirectory(directory_, ".*.pcd", false);
         for(size_t i=0; i < test_cloud.size(); i++)
         {
             pcl::PointCloud<PointT> cloud;


### PR DESCRIPTION
...  as in all other packages in this repository. This is needed for `prepare_release` to work. See https://lcas.lincoln.ac.uk/jenkins/job/prepare-release/382/console for an example where this had failed.
