### PR TITLE
and another package version not initialised

### DIFF
--- a/object_tracker_srv_definitions/package.xml
+++ b/object_tracker_srv_definitions/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>object_tracker_srv_definitions</name>
-  <version>0.0.0</version>
+  <version>0.0.10</version>
   <description>The object_tracker_srv_definitions package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 


### PR DESCRIPTION
before a repository can be released, _all_ `package.xml` need to have the same version or [`prepare-release`](https://lcas.lincoln.ac.uk/jenkins/job/prepare-release/383/console) is doomed to fail :-(
