### PR TITLE
Object pose and object tracker confidence

### DIFF
--- a/object_tracker/include/object_tracker.h
+++ b/object_tracker/include/object_tracker.h
@@ -29,6 +29,7 @@
 #include "object_tracker_srv_definitions/stop_tracker.h"
 #include "object_tracker_srv_definitions/cleanup.h"
 #include "object_tracker_srv_definitions/change_tracking_model.h"
+#include "object_tracker_msg_definitions/Confidence.h"
 
 #include <ros/ros.h>
 #include <sensor_msgs/PointCloud2.h>

--- a/object_tracker/include/object_tracker.h
+++ b/object_tracker/include/object_tracker.h
@@ -29,7 +29,7 @@
 #include "object_tracker_srv_definitions/stop_tracker.h"
 #include "object_tracker_srv_definitions/cleanup.h"
 #include "object_tracker_srv_definitions/change_tracking_model.h"
-#include "object_tracker_msg_definitions/Confidence.h"
+#include "object_tracker_msg_definitions/ObjectInfo.h"
 
 #include <ros/ros.h>
 #include <sensor_msgs/PointCloud2.h>

--- a/object_tracker/src/object_tracker.cpp
+++ b/object_tracker/src/object_tracker.cpp
@@ -170,8 +170,8 @@ ObjTrackerMono::start (object_tracker_srv_definitions::start_tracker::Request & 
     cam_tracker_stop_  = n_->advertiseService ("stop_recording", &ObjTrackerMono::stop, this);
     cam_tracker_cleanup_  = n_->advertiseService ("cleanup", &ObjTrackerMono::cleanup, this);
     camera_topic_subscriber_ = n_->subscribe(camera_topic_ +"/points", 1, &ObjTrackerMono::trackNewCloud, this);
-    confidence_publisher_ = n_->advertise<std_msgs::Float32>("object_tracker_confidence", 1);
-    object_pose_publisher_ = n_->advertise<geometry_msgs::Transform>("object_pose", 1);
+    confidence_publisher_ = n_->advertise<object_tracker_msg_definitions::Confidence>("object_tracker_confidence", 1);
+    object_pose_publisher_ = n_->advertise<geometry_msgs::TransformStamped>("object_pose", 1);
 
     cv::namedWindow( "image", CV_WINDOW_AUTOSIZE );
     return true;
@@ -245,8 +245,9 @@ ObjTrackerMono::trackNewCloud(const sensor_msgs::PointCloud2Ptr& msg)
         time = t.getTime();
     }
 
-    std_msgs::Float32 confROS;
+    object_tracker_msg_definitions::Confidence confROS;
     confROS.data = conf_;
+    confROS.header.stamp = ros::Time::now();
     confidence_publisher_.publish(confROS);
 
     if(debug_image_publisher_.getNumSubscribers())
@@ -255,17 +256,19 @@ ObjTrackerMono::trackNewCloud(const sensor_msgs::PointCloud2Ptr& msg)
 
         if (conf_>0.05)
         {
-            geometry_msgs::Transform tt;
-            tt.translation.x = pose_(0,3);
-            tt.translation.y = pose_(1,3);
-            tt.translation.z = pose_(2,3);
+            geometry_msgs::TransformStamped tt;
+            tt.transform.translation.x = pose_(0,3);
+            tt.transform.translation.y = pose_(1,3);
+            tt.transform.translation.z = pose_(2,3);
 
             Eigen::Matrix3f rotation = pose_.block<3,3>(0,0);
             Eigen::Quaternionf q(rotation);
-            tt.rotation.x = q.x();
-            tt.rotation.y = q.y();
-            tt.rotation.z = q.z();
-            tt.rotation.w = q.w();
+            tt.transform.rotation.x = q.x();
+            tt.transform.rotation.y = q.y();
+            tt.transform.rotation.z = q.z();
+            tt.transform.rotation.w = q.w();
+
+            tt.header.stamp = confROS.header.stamp;
             object_pose_publisher_.publish(tt);
 
             if (log_cams_)

--- a/object_tracker_msg_definitions/CMakeLists.txt
+++ b/object_tracker_msg_definitions/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(object_tracker_msg_definitions)
+
+find_package(catkin REQUIRED COMPONENTS std_msgs message_generation)
+
+add_message_files(
+  FILES
+    Confidence.msg
+)
+
+generate_messages(
+   DEPENDENCIES
+   std_msgs
+)
+ 
+catkin_package()
+

--- a/object_tracker_msg_definitions/CMakeLists.txt
+++ b/object_tracker_msg_definitions/CMakeLists.txt
@@ -1,16 +1,17 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(object_tracker_msg_definitions)
 
-find_package(catkin REQUIRED COMPONENTS std_msgs message_generation)
+find_package(catkin REQUIRED COMPONENTS std_msgs geometry_msgs message_generation)
 
 add_message_files(
   FILES
-    Confidence.msg
+	ObjectInfo.msg
 )
 
 generate_messages(
    DEPENDENCIES
    std_msgs
+   geometry_msgs
 )
  
 catkin_package()

--- a/object_tracker_msg_definitions/msg/Confidence.msg
+++ b/object_tracker_msg_definitions/msg/Confidence.msg
@@ -1,5 +1,0 @@
-# This express confidence of the object with a header
-# in that way you can sync with other topics
-
-Header header
-float32 data

--- a/object_tracker_msg_definitions/msg/Confidence.msg
+++ b/object_tracker_msg_definitions/msg/Confidence.msg
@@ -1,0 +1,5 @@
+# This express confidence of the object with a header
+# in that way you can sync with other topics
+
+Header header
+float32 data

--- a/object_tracker_msg_definitions/msg/ObjectInfo.msg
+++ b/object_tracker_msg_definitions/msg/ObjectInfo.msg
@@ -1,0 +1,7 @@
+# This represents the transform between camera and object frame in free space.
+# With the confidence of the tracking
+
+geometry_msgs/Vector3 translation
+geometry_msgs/Quaternion rotation
+
+float64 confidence

--- a/object_tracker_msg_definitions/package.xml
+++ b/object_tracker_msg_definitions/package.xml
@@ -40,7 +40,9 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   
 

--- a/object_tracker_msg_definitions/package.xml
+++ b/object_tracker_msg_definitions/package.xml
@@ -1,29 +1,23 @@
 <?xml version="1.0"?>
 <package>
-  <name>object_tracker</name>
+  <name>object_tracker_msg_definitions</name>
   <version>0.1.4</version>
-  <description>Tracks on demand the full pose of a (previously) modelled object</description>
-
+  <description>The object_tracker_srv_definitions package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="prankl@acin.tuwien.ac.at">Thomas Faeulhammer</maintainer>
   <maintainer email="faeulhammer@acin.tuwien.ac.at">Thomas Faeulhammer</maintainer>
   <maintainer email="alexandrov@acin.tuwien.ac.at">Sergey Alexandrov</maintainer>
   <maintainer email="zillich@acin.tuwien.ac.at">Michael Zillich</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>MIT</license>
 
 
   <!-- Url tags are optional, but mutiple are allowed, one per tag -->
   <!-- Optional attribute type can be: website, bugtracker, or repository -->
   <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/object_tracker</url> -->
+  <!-- <url type="website">http://wiki.ros.org/recognition_srv_definitions</url> -->
 
 
   <!-- Author tags are optional, mutiple are allowed, one per tag -->
@@ -44,35 +38,19 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>tf_conversions</build_depend>
-  <build_depend>object_tracker_srv_definitions</build_depend>
-  <build_depend>object_tracker_msg_definitions</build_depend>
-  <build_depend>tf2</build_depend>
-  <build_depend>visualization_msgs</build_depend>
-  <build_depend>cv_bridge</build_depend>
-  <build_depend>image_transport</build_depend>
-  <build_depend>pcl_conversions</build_depend>
-  <build_depend>v4r</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
+  
 
-  <run_depend>roscpp</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>tf_conversions</run_depend>
-  <run_depend>object_tracker_srv_definitions</run_depend>
-  <run_depend>object_tracker_msg_definitions</run_depend>
-  <run_depend>tf2</run_depend>
-  <run_depend>visualization_msgs</run_depend>
-  <run_depend>cv_bridge</run_depend>
-  <run_depend>image_transport</run_depend>
-  <run_depend>pcl_conversions</run_depend>
-  <run_depend>v4r</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
+    <!-- You can specify that this package is a metapackage here: -->
+    <!-- <metapackage/> -->
+
     <!-- Other tools can request additional information be placed here -->
 
   </export>


### PR DESCRIPTION
I think that should be nice to have stamped the messages of `/object_tracker/object_pose` and `/object_tracker/object_tracker_confidence`. So we can know which confidence have every pose.
To do that I have created a new message (Confidence.msg) in a new package (may be could be in the object_tracker_srv_definitions changing this name). And I have used TransformStamped instead of Transform. May be a better solution should be create a new message for the Transform in the way that nobody, who is using `v4r_ros_wrappers`, should not change their code.

What do you think about that?
